### PR TITLE
Docs Compose Side-Effect

### DIFF
--- a/study/UI Architecture/Compose Phases.md
+++ b/study/UI Architecture/Compose Phases.md
@@ -77,18 +77,15 @@ println(padding)
 > - 컴포즈는 3가지 단계에서 어떤 상태를 확인하는지 자동으로 추적할 수 있으며, 이를 통해 특정 단계만을 실행하도록 알릴 수 있음
 > - 중요한 점은 `SnapshotState`가 생성되는 지점이 아닌, 어디서 확인(읽는)하는지 이며, 이를 통해 컴포즈가 상태를 추적하도록 함
 > - Composable or Composable Block에서 상태를 확인하면 `Composition - Layout - Drawing` 3 단계에 영향을 미침
-    >
-- 상태 값이 변경된 경우 리컴포저는 해당 상태 값을 읽은 모든 컴포저블 함수를 다시 실행하도록 예약
+>   - 상태 값이 변경된 경우 리컴포저는 해당 상태 값을 읽은 모든 컴포저블 함수를 다시 실행하도록 예약
 >   - 만약 상태 값이 변경되지 않았다면 런타임은 일부 또는 모든 Composable 함수를 건너뛸 수 있음
 >   - `Composition` 결과에 따라 `Layout - Drawing`을 실행하지만, UI 요소의 크기나 레이아웃이 변경되지 않았다면 건너뛸 수 있음
 > - '측정'과 '배치' 단계에서 상태를 확인하면 `Layout - Drawing` 단계에 영향을 미칠 수 있음
-    >
-- '측정'에서 상태를 Layout 컴포저블에 전달된 `measurePolicy`, `LayoutModifier` 인터페이스의 `MeasureScope.measure` 메서드 등에서 사용한 경우
+>   - '측정'에서 상태를 Layout 컴포저블에 전달된 `measurePolicy`, `LayoutModifier` 인터페이스의 `MeasureScope.measure` 메서드 등에서 사용한 경우
 >   - '배치'에서 상태를 Layout 컴포저블의 배치 블록, `Modifier.offset { … }`의 람다 블록 등에서 사용하는 경우
 > - '측정'과 '배치' 단계는 별도의 재시작 범위를 가지지만, [서로 얽혀있기에 서로의 재시작 범위에 영향을 줄 수 있음](#측정과-배치-서로의-영향)
 > - UI를 그리는 중 상태를 확인하면 `Drawing` 단계만 영향을 줌
-    >
-- `Canvas`, `Modifier.drawBehind`, `Modifier.drawWithContent` 등의 그리기 코드에서 상태를 사용하는 경우
+>   - `Canvas`, `Modifier.drawBehind`, `Modifier.drawWithContent` 등의 그리기 코드에서 상태를 사용하는 경우
 
 컴포즈의 3가지 주요 단계가 있고, 각 단계에서 어떤 상태를 확인했는지 컴포즈가 자동으로 추적합니다.  
 이를 통해 컴포즈는 특정 UI 요소에 영향을 주는 작업을 수행해야 하는 특정 단계만을 알릴 수 있습니다.

--- a/study/UI Architecture/Compose의 Side-Effect.md
+++ b/study/UI Architecture/Compose의 Side-Effect.md
@@ -45,6 +45,10 @@ Compose는 이러한 요구사항을 충족하기 위해 다양한 'Side-Effect 
 > - derivedStateOf
 >   - 'Compose'에서 'State', 'Composable 입력'이 실제 필요한 UI 업데이트 보다 자주 변경될 때 사용
 >   - 'Scroll Position'과 같이 빈번하게 변경되지만 특정 시기에만 반응해야 하는 'State'를 다룰 때 사용
+> - snapshotFlow
+>   - 'Compose' `State<T>`를 `Flow`로 변환할 때 사용
+>   - '터미널 연산' 호출 시, '람다 블록'을 실행하며 'State' 결과를 내보냄
+>   - '람다 블록'에서 읽힌 'State' 중 하나라도 변경되면 '람다 블록'을 재실행
 
 컴포저블은 UI 작업 외, 'Side-Effect' 작업을 하지 않는게 좋습니다.  
 하지만, 때떄로 앱의 '상태'를 변경해야 하는 경우 `Effect` API를 통해 처리할 수 있습니다.
@@ -343,12 +347,13 @@ val fullNameCorrect = "$firstName $lastName" // 올바른 사용 방식
 ---
 
 ### snapshotFlow: convert Compose's State into Flows
-`snapshotFlow`는 Compose의 `State<T>` 객체를 `Cold Flow`로 변환하는 데 사용됩니다.  
-`snapshotFlow`는 `Collect`시 실행되고, 그 안에서 읽히는 `State` 객체의 결과를 `emit` 합니다.   
-`snapshotFlow` 블록 내에서 읽히는 `State` 객체 중 하나가 변경되면, `Flow`는 새 값을 수집기에 `emit` 합니다.   
-이 새 값이 이전에 `emit` 된 값과 **같지 않은 경우에만 이런 동작이 발생**합니다 (`Flow.distinctUntilChanged`의 동작과 유사합니다).
 
-다음 예는 사용자가 리스트의 첫 번째 아이템을 스크롤하여 지나갈 때 analytics에 이를 기록하는 `Side-Effect`를 보여줍니다:
+`snapshotFlow`는 'Compose'의 `State<T>`를 `Flow`로 변환하는데 사용됩니다.
+
+`snapshotFlow`는 '터미널 연산'이 호출되면 `block`을 실행하고, 그 안에 읽힌 `State` 결과를 내보냅니다.  
+또한 `block` 내에서 읽힌 `State` 중 하나가 변경되면 `block`을 다시 실행합니다. 그 후 새로운 값이 이전에 내보낸 값과 다를 경우, `Flow`는 새로운 값을 내보냅니다.
+
+다음 예제는 사용자 목록의 첫 번째 항목을 스크롤할 때 Analytics 기록하는 'Side-Effect'의 예시입니다.
 
 ```kotlin
 val listState = rememberLazyListState()
@@ -367,8 +372,6 @@ LaunchedEffect(listState) {
         }
 }
 ```
-
-위의 코드에서 `listState.firstVisibleItemIndex`는 `Flow`의 연산자의 확장 함수들을 활용할 수 있는 `Flow`로 변환됩니다.
 
 ---
 

--- a/study/UI Architecture/Compose의 Side-Effect.md
+++ b/study/UI Architecture/Compose의 Side-Effect.md
@@ -409,6 +409,7 @@ EffectName(ifThisKeyChanges, orThisKeyChanges, orThisKeyChanges, ...) { block }
 
 ---
 
-## 상수를 키로 사용하기
-호출 위치의 `Lifecycle`을 따르게 하려면 상수를 `Effect`의 `Key`로 사용할 수 있습니다.   
-그러나 이렇게 실행하기 전에 두 번 생각하고 그것이 정말 필요한지 확인하십시오.
+### Constants as keys
+
+`Effect`에서 상수(`true`)를 `Key`로 사용하는 것은 해당 `Effect`를 'Call site'의 생명 주기에 따르게 하기 위한 방법 중 하나 입니다. 
+그러나 상수를 `Key`로 사용하면 `Effect`는 재시작되지 않습니다. 즉, 한 번만 실행되는 경우에 유용할 수 있습니다.


### PR DESCRIPTION
- Compose Effect 종류 정리
  -  ReComposition 참조 유지
  - Composable 제거 및 Key 변경 -> Side-Effect 관리
  - 'Compose State'를 'Non-Compose Code'로 공유
  - 'Non-Compose State' -> 'Compose State' 전환
  - 빈번한 State 변경 대응
  - 'Compose State' -> 'Flow' 전환
- Effect API 관리 원칙