### PR TITLE
Docs Compose best practices

### DIFF
--- a/study/Performance를 위한 좋은 사례.md
+++ b/study/Performance를 위한 좋은 사례.md
@@ -1,13 +1,16 @@
 # Follow Best Practices
 
-### 비용이 많이드는 계산을 최소화 하기 위해 `remember` 사용
-Composable은 Animation의 모든 프레임마다 실행되는 정도로 자주 재실행될 수 있습니다. 
-이러한 이유로, composable의 내부는 가능한 적은 계산을 수행하도록 설계해야 합니다.
+## Use `remember` to minimize expensive calculations
 
-이를 위해서 Compose에서는 `remember`라는 기능을 제공합니다.
-`remember`는 계산된 결과를 저장하는것으로 이 계산은 1번만 수행되며, 필요할 때 마다 결과를 가져올 수 있습니다.
+> - `remember`는 연결된 'Composable'이 'ReComposition' 될 때까지만 값 저장
+> - 'Composable'이 'Composition'에서 제거되면 `remember`로 저장된 값도 초기화 됨
+> - `remember`는 `Key`를 파라미터로 받을 수 있으며, 해당 `Key`가 변경될 때 저장된 값을 재계산
+> - `remember` 사용 시, 큰 데이터 또는 복잡한 객체를 저장하면 '메모리 사용량이 증가'할 수 있기에 **주의**
 
-다음 코드는 정렬한 연락처를 목록으로 표시하지만, 정렬을 비효율적으로 처리하는 예시 입니다.
+'Composable'은 애니메이션의 각 프레임마다 자주 실행될 수 있기에, 'Composable' 내에서 수행되는 '계산'은 최소화해야 합니다.  
+이를 위해 `remember`를 사용하여 '한 번만 계산을 실행'하고 그 '결과를 저장'하여 필요할 때마다 결과를 가져오게 할 수 있습니다.
+
+예를 들어, 목록을 정렬하는데 많은 비용이 드는 방식으로 정렬을 수행하는 코드가 있다고 가정하면 다음과 같습니다.
 
 ```kotlin
 @Composable
@@ -25,10 +28,10 @@ fun ContactList(
 }
 ```
 
-`ContactsList()`가 재구성될 때마다, 전체 연락처 목록이 다시 정렬되지만, 목록 자체는 변하지 않았습니다. 
-사용자가 목록을 스크롤하면, 새로운 행이 나타날 때마다 Composable이 재구성됩니다.
+위 코드는 `ContactList`가 'ReComposition' 될 때마다 전체 연락처 목록이 재정렬 됩니다.  
+이는 사용자가 목록을 스크롤하여 새로운 행이 나타날 때마다 'Composable'이 'ReComposition' 되며, `contacts`가 변경되지 않아도 목록이 재정렬 됩니다.
 
-이 문제를 해결하기 위해, `LazyColumn` 외부에서 목록을 정렬하고, 정렬된 목록을 `remember`를 통해 저장해야 합니다.
+이 문제를 해결하기 위해 `LazyColumn` 외부에서 목록을 정렬하고, 정렬된 목록을 `remember`로 저장하여 계산을 최소화 할 수 있습니다.
 
 ```kotlin
 @Composable
@@ -37,8 +40,8 @@ fun ContactList(
     comparator: Comparator<Contact>,
     modifier: Modifier = Modifier
 ) {
-    val sortedContacts = remember(contacts, sortComparator) {
-        contacts.sortedWith(sortComparator)
+    val sortedContacts = remember(contacts, comparator) {
+        contacts.sortedWith(comparator)
     }
 
     LazyColumn(modifier) {
@@ -49,9 +52,9 @@ fun ContactList(
 }
 ```
 
-이제, `ContactList()`가 처음 구성될 때 목록이 한 번 정렬됩니다. 
-만약 연락처나 비교자가 변경되면, 정렬된 목록이 재생성됩니다. 
-그렇지 않다면, composable은 캐시된 정렬된 목록을 계속 사용할 수 있습니다.
+이제 연락처 목록은 `ContactList`가 Composition 될 때 1번만 정렬됩니다.  
+만약 `contacts`나 `comparator`가 변경되면 `sortedContacts`를 재생성하게 됩니다.  
+그런 경우가 아니라면 'Composable'은 캐싱된 `sortedContacts`를 계속 사용할 수 있습니다.
 
 ---
 

--- a/study/Performance를 위한 좋은 사례.md
+++ b/study/Performance를 위한 좋은 사례.md
@@ -109,10 +109,12 @@ fun NotesList(notes: List<Note>) {
 
 ---
 
-### derivedStateOf을 사용하여 재구성 횟수 제한
+## Use `derivedStateOf` to limit recompositions
 
-Composition에서 상태를 사용할 때 발생할 수 있는 위험 중 하나는 상태가 급속하게 변경될 경우 UI가 필요 이상으로 재구성 될 수 있다는 점입니다.  
-예를 들어, 스크롤 가능한 목록을 표시하는 경우가 있습니다. 목록의 상태를 검사하여 목록에서 첫 번째로 표시되는 항목을 확인합니다.
+> - 'State' 변화가 빠르게 일어날 때, `derivedStateOf`를 사용하여 필요한 경우에만, UI 'ReComposition' 하는 것이 효율적
+
+`derivedStateOf`를 사용하여 'ReComposition'을 제한하는 것은 효율적인 UI 업데이트를 위한 중요한 방법입니다.  
+사용자가 스크롤하는 것과 같이 'State' 변화가 매우 빠르게 일어날 때, `derivedStateOf`를 사용하여 필요한 경우에만 UI를 'ReComposition' 하는 것이 효율적 입니다.
 
 ```kotlin
 val listState = rememberLazyListState()
@@ -128,12 +130,9 @@ AnimatedVisibility(visible = showButton) {
 }
 ```
 
-여기에서 사용자가 목록 스크롤 시, 사용자의 손가락을 드래그하는 동안 `listState`가 계속 변경되는것이 문제입니다.
-즉, 목록이 계속해서 재구성됩니다. 그러나 실제로는 새로운 항목이 하단에 보이게 될 때까지 재구성할 필요가 없습니다.
-따라서 이는 많은 추가 계산을 하고 있음을 의미하며, 이로인한 UI 성능이 저하 됩니다.
+위 예시와 같이 `listState.firstVisibleItemIndex > 0`는 스크롤 할 때마다 'State'가 변경될 수 있기에 불필요한 'ReComposition'이 발생되며 성능 저하를 야기할 수 있습니다.
 
-해결책으로는 `derivedState`를 사용하는 것입니다. 이를 사용하면 어떤 상태의 변경이 실제로 재구성을 트리거해야 하는지 Compose에 알려줄 수 있습니다.  
-위 경우엔, 첫 번째로 보이는 항목이 언제 변경되는지에 대한 관심이 있다고 명시되어 있기에, 그 상태 값이 변경되면 UI를 재구성해야 합니다.
+이를 위한 해결책으로 `dervidedStateOf`를 사용하여 실제 중요한 'State' 변화 시, 'ReComposition'을 트리거 할 수 있습니다.
 
 ```kotlin
 val listState = rememberLazyListState()

--- a/study/Performance를 위한 좋은 사례.md
+++ b/study/Performance를 위한 좋은 사례.md
@@ -58,17 +58,21 @@ fun ContactList(
 
 ---
 
-### Lazy Layout 사용시 Key 적용
+## Use Lazy layout keys
 
-`Lazy` 접두어를 사용하는 레이아웃들은 아이템을 최대한 재사용하고, 필요할 때만 재성성하거나 재구성하도록 합니다.   
-추가로, 개발자들은 Key를 사용하여 이러한 동작을 더 최적화할 수 있습니다.
+> - 'Compose'는 목록 중 하나의 항목이 이동되었을 때, 해당 항목만 'ReComposition' 하지 않고, 전체 목록을 'ReComposition' 함 
+>   이를 위해 'Lazy Layout'에 Key를 제공하여 'ReComposition'을 최소화하여 해당 항목만 'ReComposition' 되도록 처리
+
+'Lazy layout'은 목록에서 항목이 이동할 때마다 모든 항목을 'ReComposition' 또는 'ReGenerate' 하는 것을 피할 수 있도록 도와줍니다.  
+특히, 목록에서 항목의 순서가 자주 변경되는 경우에 'Lazy 레이아웃'을 사용하는 것이 효율적 입니다.
+
+아래 예시는 '수정한 시간 별'로 정렬된 노트 목록을 보여주고 있습니다.
 
 ```kotlin
 @Composable
 fun NotesList(notes: List<Note>) {
     LazyColumn {
         items(
-            key = { note -> note.id },
             items = notes
         ) { note ->
             NoteRow(note)
@@ -76,8 +80,32 @@ fun NotesList(notes: List<Note>) {
     }
 }
 ```
-위처럼 `key`를 적용하지 않은 경우, `note` 목록이 변경될 경우 모든 `note`를 재구성하겠지만, 
-위와 같이 해당 아이템에 `key`를 제공함으로써, 재구성 시 변경된 노트만 재구성을 하여 불필요한 재구성을 피할 수 있습니다. 
+
+이 때 사용자가 가장 아래에 있던 노트를 가장 최근에 수정하여 목록의 맨 위로 이동한다면,   
+위 방식의 'Lazy layout'은 변경되지 않은 노트 항목들도 'ReComposition' 될 수 있습니다.  
+이는 'Compose'가 단순히 목록에서 항목들이 이동헸다는 것을 인지하지 않고, 각 항목이 삭제되고 새로 생성된 것으로 간주하기 때문입니다.  
+이런 방식은 효율성이 떨어지고 불필요한 'ReComposition'을 야기합니다.
+
+이 문제를 해결하기 위해 각 항목에 대한 'Stable Key'를 제공하는 것이 좋습니다.  
+이 'Key'는 각 항목을 '고유하게 식별'할 수 있게 해주며, 'Compose'가 항목이 단순히 이동했음을 인식하고 
+데이터 변경이 없는 항목에 대해서는 'ReComposition'을 '스킵'할 수 있도록 합니다.
+
+```kotlin
+@Composable
+fun NotesList(notes: List<Note>) {
+    LazyColumn {
+        items(
+            items = notes,
+            key = { note ->
+                // Key 
+                note.id
+            }
+        ) { note ->
+            NoteRow(note)
+        }
+    }
+}
+```
 
 ---
 


### PR DESCRIPTION
- `remember` 연산 비용이 높은 값 저장
- List 표현 'Lazy layout'에서 'Key'를 적용하여 'ReComposition' 최적화
- 'State'가 빈번하게 변경되는 경우 `derivedStateOf` 사용
- 'lmabda'로 상태 참조 시 ReComposition 최소화
- 'lmabda modifier' 사용 시 Composition Skip
- 'backwards write' 방지 필요